### PR TITLE
As

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 [mut](https://tourofrust.com/04_ja.html)
 
 [基本的な型](https://tourofrust.com/05_ja.html)
+
+[基本型の変換](https://tourofrust.com/06_ja.html)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@
 [基本的な型](https://tourofrust.com/05_ja.html)
 
 [基本型の変換](https://tourofrust.com/06_ja.html)
+
+[定数](https://tourofrust.com/07_ja.html)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
-fn main() {
-    let a = 13u8;
-    let b = 7u32;
-    let c = a as u32 + b;
-    println!("{}", c);
+const PI: f32 = 3.14159;
 
-    let t = true;
-    println!("{}", t as u8);
+fn main() {
+    println!(
+        "ゼロからアップル {} を作るには、まず宇宙を創造する必要があります。",
+        PI
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,9 @@
 fn main() {
-    let x = 12; // デフォルトでは i32
-    let a = 12u8;
-    let b = 4.3; // デフォルトでは f64
-    let c = 4.3f32;
-    let bv = true;
-    let t = (13, false);
-    let sentence = "hello world!";
-    println!(
-        "{} {} {} {} {} {} {} {}",
-        x, a, b, c, bv, t.0, t.1, sentence
-    );
+    let a = 13u8;
+    let b = 7u32;
+    let c = a as u32 + b;
+    println!("{}", c);
+
+    let t = true;
+    println!("{}", t as u8);
 }


### PR DESCRIPTION
# Background
learning to as.

## What I did
write as code.

基本型の変換
Rust で数値型を扱う際、型を明示する必要があります。u8 と u32 を混ぜるとエラーになります。

幸い、Rust は as キーワードで数値型を簡単に変換できます。

